### PR TITLE
Player page button sizing

### DIFF
--- a/public/player.html
+++ b/public/player.html
@@ -80,7 +80,7 @@
         <div class="d-flex ms-auto mt-2 mt-lg-0 align-items-center gap-2">
           <a id="open-original" class="btn btn-outline-light btn-sm d-none" target="_blank" rel="noopener noreferrer">Open original</a>
           <span id="user-name" class="navbar-text me-1"></span>
-          <button id="log-off" class="btn btn-danger btn-sm">Déconnexion</button>
+          <button id="log-off" class="btn btn-danger">Déconnexion</button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Remove `btn-sm` class from the logout button on `player.html` to standardize its size with other pages.

---
<a href="https://cursor.com/background-agent?bcId=bc-0b50f929-5091-4797-b2a7-ab2c77fcf9e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0b50f929-5091-4797-b2a7-ab2c77fcf9e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

