### PR TITLE
Admin panel version styling

### DIFF
--- a/public/control.html
+++ b/public/control.html
@@ -66,11 +66,6 @@
       </button>
     </li>
     <li class="nav-item" role="presentation">
-      <button class="nav-link" id="admin-version-tab" data-bs-toggle="tab" data-bs-target="#admin-version" type="button" role="tab" aria-controls="admin-version" aria-selected="false">
-        Version
-      </button>
-    </li>
-    <li class="nav-item" role="presentation">
       <button class="nav-link" id="admin-movies-tab" data-bs-toggle="tab" data-bs-target="#admin-movies" type="button" role="tab" aria-controls="admin-movies" aria-selected="false">
         Films
       </button>
@@ -93,6 +88,11 @@
     <li class="nav-item" role="presentation">
       <button class="nav-link" id="admin-backup-tab" data-bs-toggle="tab" data-bs-target="#admin-backup" type="button" role="tab" aria-controls="admin-backup" aria-selected="false">
         Backup / Restore
+      </button>
+    </li>
+    <li class="nav-item" role="presentation">
+      <button class="nav-link" id="admin-version-tab" data-bs-toggle="tab" data-bs-target="#admin-version" type="button" role="tab" aria-controls="admin-version" aria-selected="false">
+        Version
       </button>
     </li>
   </ul>
@@ -204,7 +204,7 @@
 
             <div class="mt-3">
               <div class="text-muted small mb-2">Historique</div>
-              <div id="app_version_list" class="border rounded p-2 bg-light" style="white-space: pre-wrap;">—</div>
+              <div id="app_version_list" class="border rounded bg-white app-version-list">—</div>
             </div>
           </div>
         </div>

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -127,3 +127,17 @@ footer {
     justify-content: flex-end;
     gap: 10px;
   }
+
+  /* Admin → Version: keep history rows clean and readable */
+  .app-version-list .list-group-item {
+    border-left: 0;
+    border-right: 0;
+  }
+
+  .app-version-list .list-group-item:first-child {
+    border-top: 0;
+  }
+
+  .app-version-list .list-group-item:last-child {
+    border-bottom: 0;
+  }

--- a/public/js/app_control.js
+++ b/public/js/app_control.js
@@ -304,24 +304,32 @@ window.onload = async function () {
       return;
     }
 
-    appVersionListEl.innerHTML = versions.map((v) => {
+    const rows = versions.map((v) => {
       const id = String(v?.id || '');
       const isActive = activeId && id === activeId;
       const dateLabel = v?.dateISO ? formatDateTime(v.dateISO) : '—';
       const msg = escapeHtml(String(v?.message || '').trim());
-      return `
-        <div class="d-flex justify-content-between align-items-start border rounded px-2 py-2 mb-2 bg-white">
-          <div class="me-2">
-            <div class="fw-semibold">
-              ${escapeHtml(String(v?.version || '—'))}
-              ${isActive ? '<span class="badge bg-warning text-dark ms-1">Active</span>' : ''}
-            </div>
-            <div class="small text-muted">${escapeHtml(dateLabel)}${msg ? ` — ${msg}` : ''}</div>
-          </div>
-          <button type="button" class="btn btn-sm btn-outline-danger" data-app-version-delete="${escapeHtml(id)}">Supprimer</button>
-        </div>
-      `;
+      const versionLabel = escapeHtml(String(v?.version || '—'));
+      const activeBadge = isActive ? '<span class="badge bg-warning text-dark">Active</span>' : '';
+
+      // IMPORTANT: keep markup compact (no preserved whitespace surprises).
+      return (
+        `<div class="list-group-item d-flex justify-content-between align-items-start gap-3">` +
+          `<div class="min-width-0 flex-grow-1">` +
+            `<div class="d-flex align-items-center gap-2 flex-wrap">` +
+              `<span class="fw-semibold text-break">${versionLabel}</span>` +
+              `${activeBadge}` +
+            `</div>` +
+            `<div class="small text-muted text-break">${escapeHtml(dateLabel)}${msg ? ` — ${msg}` : ''}</div>` +
+          `</div>` +
+          `<div class="flex-shrink-0">` +
+            `<button type="button" class="btn btn-sm btn-outline-danger" data-app-version-delete="${escapeHtml(id)}">Supprimer</button>` +
+          `</div>` +
+        `</div>`
+      );
     }).join('');
+
+    appVersionListEl.innerHTML = `<div class="list-group list-group-flush">${rows}</div>`;
 
     appVersionListEl.querySelectorAll('button[data-app-version-delete]').forEach((btn) => {
       btn.addEventListener('click', async () => {


### PR DESCRIPTION
Fix broken styling of the admin panel's version history and reorder the Version tab.

The version history layout was broken due to `white-space: pre-wrap` preserving template indentation, causing the layout to explode. This PR re-renders the history as a clean Bootstrap list of row items.

---
<a href="https://cursor.com/background-agent?bcId=bc-93fc8f01-df22-4580-bdaf-18b8a905d8b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-93fc8f01-df22-4580-bdaf-18b8a905d8b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

